### PR TITLE
Show expiry date from UserInfo

### DIFF
--- a/src/VpnPortalModule.php
+++ b/src/VpnPortalModule.php
@@ -138,7 +138,7 @@ class VpnPortalModule implements ServiceModuleInterface
                     $this->tpl->render(
                         'vpnPortalConfigurations',
                         [
-                            'expiryDate' => $this->getExpiryDate(new DateInterval($this->config->getItem('sessionExpiry'))),
+                            'expiryDate' => ($userInfo->getSessionExpiresAt())->format("Y-m-d H:i:s"),
                             'profileList' => $visibleProfileList,
                             'userCertificateList' => $showAll ? $userCertificateList : $manualCertificateList,
                         ]


### PR DESCRIPTION
In the vpnPortalConfigurations view, a recomputed expiry date/time is shown, instead of the one as provided from the UserInfo. To make it feasible to use a session expiry time that is pushed from the authentication handler, the view should represent the correct date/time.