### PR TITLE
Make implements for custom auth work

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -264,12 +264,12 @@ try {
             );
 
             $implementedInterfaces = class_implements($userAuth);
-            if (!in_array('\LC\Common\Http\BeforeHookInterface', $implementedInterfaces, true)) {
+            if (!in_array('LC\Common\Http\BeforeHookInterface', $implementedInterfaces, true)) {
                 throw new RuntimeException('authentication class MUST implement "LC\Common\Http\BeforeHookInterface"');
             }
             $service->addBeforeHook('auth', $userAuth);
             // optional "ServiceModuleInterface"
-            if (in_array('\LC\Common\Http\ServiceModuleInterface', $implementedInterfaces, true)) {
+            if (in_array('LC\Common\Http\ServiceModuleInterface', $implementedInterfaces, true)) {
                 $service->addModule($userAuth);
             }
     }


### PR DESCRIPTION
It is possible to use a custom authentication mechanism. In the web/index.php script, there is a generic setup available for handling such case. In this setup, a check is done to see what interfaces
are implemented by the mechanism class.

This interfaces check seems to be using wrong interface names. The namespace that is checked against uses a backslash at the start. However (on my system at least, PHP 7.3.x) the class_implements() function returns namespaces without the leading backslash, causing the code to fail.