### PR TITLE
Add symlinked artwork files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 /config/views
 /.phpunit.cache
 /.php-cs-fixer.cache
+
+# Symlinked resources from other repositories.
+/web/css
+/web/img
+/web/fonts
+/views/LC
+/views/eduVPN
+/locale/LC
+/locale/eduVPN


### PR DESCRIPTION
In the development setup, some symlinks are created, pointing to LC and eduVPN
artwork files from other repositories. I already ran into accidentally committing
a few of these symlinks.

This change adds these symlinked resources to prevent this.