### PR TITLE
portal-number

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -21,6 +21,8 @@ return [
     // 'sessionExpiry' => 'P1D',   // 1 day
     // 'sessionExpiry' => 'PT12H', // 12 hours
 
+    // 'portalNumber' => 0,
+    
     // Portal Database Configuration
     // NOTE: using any other database than SQLite requires *manual*
     // initialization and migration!

--- a/schema/2022022201_2022080901.migration
+++ b/schema/2022022201_2022080901.migration
@@ -1,0 +1,98 @@
+
+/* certificates */
+ALTER TABLE certificates RENAME TO _certificates;
+
+CREATE TABLE IF NOT EXISTS certificates(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    node_number BIGINT NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    common_name VARCHAR(255) UNIQUE NOT NULL,
+    created_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    auth_key VARCHAR(255) REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+INSERT INTO certificates (node_number, profile_id, display_name, common_name, created_at, expires_at, auth_key, user_id) 
+SELECT (node_number, profile_id, display_name, common_name, created_at, expires_at, auth_key, user_id)  FROM _certificates;
+
+DROP TABLE _certificates;
+
+
+
+/* wg_peers */
+ALTER TABLE wg_peers RENAME TO _wg_peers;
+
+CREATE TABLE IF NOT EXISTS wg_peers (
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    node_number BIGINT NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    public_key VARCHAR(255) NOT NULL UNIQUE,
+    ip_four VARCHAR(255) NOT NULL UNIQUE,
+    ip_six VARCHAR(255) NOT NULL UNIQUE,
+    created_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    auth_key VARCHAR(255) REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+INSERT INTO wg_peers (node_number, profile_id, display_name, public_key, ip_four, ip_six, created_at, expires_at, auth_key, user_id) 
+SELECT (node_number, profile_id, display_name, public_key, ip_four, ip_six, created_at, expires_at, auth_key, user_id)  FROM _wg_peers;
+
+DROP TABLE _wg_peers;
+
+/* connection_log */
+ALTER TABLE connection_log RENAME TO _connection_log;
+
+CREATE TABLE IF NOT EXISTS connection_log(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    user_id VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    vpn_proto VARCHAR(255) NOT NULL,
+    connection_id VARCHAR(255) NOT NULL,
+    ip_four VARCHAR(255) NOT NULL,
+    ip_six VARCHAR(255) NOT NULL,
+    connected_at VARCHAR(255) NOT NULL,
+    bytes_in BIGINT DEFAULT NULL,
+    bytes_out BIGINT DEFAULT NULL,
+    disconnected_at VARCHAR(255) DEFAULT NULL
+);
+
+INSERT INTO connection_log (user_id, profile_id, vpn_proto , connection_id, ip_four, ip_six, connected_at, bytes_in, bytes_out, disconnected_at) 
+SELECT (user_id, profile_id, vpn_proto , connection_id, ip_four, ip_six, connected_at, bytes_in, bytes_out, disconnected_at)  FROM _connection_log;
+
+DROP TABLE _connection_log;
+
+/* live_stats */
+ALTER TABLE live_stats RENAME TO _live_stats;
+
+CREATE TABLE IF NOT EXISTS live_stats(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    date_time VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    connection_count BIGINT NOT NULL
+);
+
+INSERT INTO live_stats (date_time, profile_id, connection_count)
+SELECT (date_time, profile_id, connection_count)  FROM _live_stats;
+
+DROP TABLE _live_stats;
+
+
+/* aggregate_stats */
+ALTER TABLE aggregate_stats RENAME TO _aggregate_stats;
+
+CREATE TABLE IF NOT EXISTS aggregate_stats(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    date VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    max_connection_count BIGINT NOT NULL,
+    unique_user_count BIGINT NOT NULL
+);
+
+INSERT INTO aggregate_stats (date, profile_id, max_connection_count, unique_user_count)
+SELECT (date, profile_id, max_connection_count, unique_user_count)  FROM _aggregate_stats;
+
+DROP TABLE _aggregate_stats;

--- a/schema/2022080901.schema
+++ b/schema/2022080901.schema
@@ -1,0 +1,77 @@
+CREATE TABLE IF NOT EXISTS users(
+    user_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    last_seen VARCHAR(255) NOT NULL,
+    permission_list TEXT NOT NULL,
+    auth_data TEXT DEFAULT NULL,
+    is_disabled BOOLEAN NOT NULL
+);
+CREATE TABLE IF NOT EXISTS local_users (
+    user_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at VARCHAR(255) NOT NULL,
+    UNIQUE(user_id)
+);
+CREATE TABLE IF NOT EXISTS oauth_authorizations (
+    auth_key VARCHAR(255) NOT NULL PRIMARY KEY,
+    client_id VARCHAR(255) NOT NULL,
+    scope VARCHAR(255) NOT NULL,
+    authorized_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    UNIQUE(auth_key)
+);
+CREATE TABLE IF NOT EXISTS oauth_refresh_token_log (
+    auth_key VARCHAR(255) NOT NULL REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    refresh_token_id VARCHAR(255) NOT NULL,
+    UNIQUE(auth_key, refresh_token_id)
+);
+CREATE TABLE IF NOT EXISTS certificates(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    node_number BIGINT NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    common_name VARCHAR(255) UNIQUE NOT NULL,
+    created_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    auth_key VARCHAR(255) REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS wg_peers (
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    node_number BIGINT NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    public_key VARCHAR(255) NOT NULL UNIQUE,
+    ip_four VARCHAR(255) NOT NULL UNIQUE,
+    ip_six VARCHAR(255) NOT NULL UNIQUE,
+    created_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    auth_key VARCHAR(255) REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS connection_log(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    user_id VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    vpn_proto VARCHAR(255) NOT NULL,
+    connection_id VARCHAR(255) NOT NULL,
+    ip_four VARCHAR(255) NOT NULL,
+    ip_six VARCHAR(255) NOT NULL,
+    connected_at VARCHAR(255) NOT NULL,
+    bytes_in BIGINT DEFAULT NULL,
+    bytes_out BIGINT DEFAULT NULL,
+    disconnected_at VARCHAR(255) DEFAULT NULL
+);
+CREATE TABLE IF NOT EXISTS live_stats(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    date_time VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    connection_count BIGINT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS aggregate_stats(
+    portal_number BIGINT NOT NULL DEFAULT 0,
+    date VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    max_connection_count BIGINT NOT NULL,
+    unique_user_count BIGINT NOT NULL
+);

--- a/src/Cfg/Config.php
+++ b/src/Cfg/Config.php
@@ -169,6 +169,7 @@ class Config
             array_merge(
                 [
                     'baseDir' => $baseDir,
+                    'portalNumber' => $this->portalNumber(),
                 ],
                 $this->s('Db')->toArray()
             )
@@ -221,4 +222,9 @@ class Config
 
         return new self(require $configFile);
     }
+
+    public function portalNumber(): int
+    {
+        return $this->requireInt('portalNumber', 0);
+    }   
 }

--- a/src/Cfg/DbConfig.php
+++ b/src/Cfg/DbConfig.php
@@ -46,4 +46,10 @@ class DbConfig
     {
         return $this->optionalString('dbPass');
     }
+
+
+    public function portalNumber(): int
+    {
+        return $this->requireInt('portalNumber');
+    }   
 }

--- a/views/vpnAdminInfo.php
+++ b/views/vpnAdminInfo.php
@@ -5,11 +5,16 @@
 <?php /** @var array<string,null|array{rel_load_average:array<int>,load_average:array<float>,cpu_count:int}> $nodeInfoList */?>
 <?php /** @var string $portalVersion */?>
 <?php /** @var array<string,array<string>> $problemList */?>
+<?php /** @var string $portalNumber */?>
 <?php $this->layout('base', ['activeItem' => 'info', 'pageTitle' => $this->t('Info')]); ?>
 <?php $this->start('content'); ?>
     <h2><?=$this->t('Server'); ?></h2>
     <table class="tbl">
         <tbody>
+            <tr>
+                <th><?=$this->t('Portal Number'); ?></th>
+                <td><?=$this->e((string) $portalNumber); ?></td>
+            </tr>
             <tr>
                 <th><?=$this->t('Version'); ?></th>
                 <td>v<?=$this->e($portalVersion); ?></td>

--- a/views/vpnAdminUserConfigList.php
+++ b/views/vpnAdminUserConfigList.php
@@ -59,11 +59,14 @@
     <?php else: ?>
         <table class="tbl">
             <thead>
-                <tr><th><?=$this->t('Profile'); ?></th><th><?=$this->t('Name'); ?></th><th><?=$this->t('Expires On'); ?></th></tr>
+                <tr><th><?=$this->t('Portal'); ?></th><th><?=$this->t('Profile'); ?></th><th><?=$this->t('Name'); ?></th><th><?=$this->t('Expires On'); ?></th></tr>
             </thead>
             <tbody>
             <?php foreach ($configList as $configEntry): ?>
                 <tr>
+                    <td>
+                        <span title="<?=$this->e((string) $configEntry['portal_number']); ?>"><?=$this->e((string) $configEntry['portal_number']); ?></span>
+                    </td>
                     <td>
                         <span title="<?=$this->e($configEntry['profile_id']); ?>"><?=$this->profileIdToDisplayName($profileConfigList, $configEntry['profile_id']); ?></span>
                     </td>
@@ -89,6 +92,7 @@
     <table class="tbl">
         <thead>
             <tr>
+                <th><?=$this->t('Portal'); ?></th>
                 <th><?=$this->t('Profile'); ?></th>
                 <th><?=$this->t('Connected'); ?></th>
                 <th><?=$this->t('Disconnected'); ?></th>
@@ -97,6 +101,7 @@
         <tbody>
 <?php foreach ($userConnectionLogEntries as $logEntry): ?>
             <tr>
+                <td title="<?=$this->e((string) $logEntry['portal_number']); ?>"><?=$this->e((string) $logEntry['portal_number']); ?></td>
                 <td title="<?=$this->e($logEntry['profile_id']); ?>"><?=$this->profileIdToDisplayName($profileConfigList, $logEntry['profile_id']); ?></td>
                 <td title="IPv4: <?=$this->e($logEntry['ip_four']); ?>, IPv6: <?=$this->e($logEntry['ip_six']); ?>"><?=$this->d($logEntry['connected_at']); ?></td>
                 <td>

--- a/web/index.php
+++ b/web/index.php
@@ -84,6 +84,7 @@ try {
             'authModule' => $config->authModule(),
             'isAdmin' => false,
             'showLogoutButton' => true,
+            'portalNumber' => $config->portalNumber(),
         ]
     );
 


### PR DESCRIPTION

this feature is to address following use cases
1. deploy multiple portals with diferent FQDN and nodes, connected ot he same Db.
2. orgnizations running multiple VPN services to access air-tight hubs need to consolidate user management and access settings. 2 portals running sperately with default maxActiveApiConfiguration => 3 allows for one user to have 6 connections. by merging 2 portals into 1 DB maxActiveApiConfiguration => 3 become global rather than by portal.
3. users dont have to authorize clients on every portal as in seperate portals deployment.

the changes in this open the road for moving config to the Db. accoridng to scope (global, portal, profile, node). yet this is not included.
in the setup we tested this, the config.php is split multiple files
```
<?php

declare(strict_types=1);
$config = [];
$defaultConfig = [];
$profileConfig = [];
$systemConfig = [];

if (file_exists(__DIR__.'/config/default-config.php') ) {
    $defaultConfig = include __DIR__.'/config/default-config.php';
}
if (file_exists(__DIR__.'/config/profile-config.php') ) {
    $profileConfig = include __DIR__.'/config/profile-config.php';
}
if (file_exists(__DIR__.'/config/system-config.php') ) {
    $systemConfig  = include __DIR__.'/config/system-config.php';
} 

$config = array_merge($defaultConfig, $systemConfig , $profileConfig);

return $config;


```


changes add new parameter to config.php
```
	'portalNumber' => 0,
```


the new parameter is used in `Storage` .

`portalNumber` is showing in portal in these sections
1. ***info*** view in the portal
2. ***user*** view `portal configurations` & `connection log`



features can be planned base don this feature release
- move global config paramters to Db (language, API, Log)
- portal `connection log` and `stats`, `live stats` to includes portalNumber and shows global figures not accessed portal only.

