### PR TITLE
profile & user settings for active configuration | user settings for connection expiry

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -21,6 +21,18 @@ return [
     // 'sessionExpiry' => 'P1D',   // 1 day
     // 'sessionExpiry' => 'PT12H', // 12 hours
 
+
+    // 'User' => [
+    
+    //      'maxActiveConfigurations' => false,
+    //      'maxActiveApiConfigurations' => false,
+
+    //      Connection_Expires_at allow to configure expiry for user connection. 
+    //      does not affect client authorization
+    //      DEFAULT = false
+    //      'connectionExpiresAt' => false,
+    // ],
+
     // Portal Database Configuration
     // NOTE: using any other database than SQLite requires *manual*
     // initialization and migration!
@@ -166,7 +178,10 @@ return [
     // ** OpenID Connect (mod_auth_openidc) **
     // 'OidcAuthModule' => [
     //    'userIdAttribute' => 'REMOTE_USER',
-    // //   'permissionAttributeList' => [],
+    //    'permissionAttributeList' => [],
+    //    'maxActiveConfigurations' => null,
+    //    'maxActiveApiConfigurations' => null,
+    //    'connectionExpiresAt' => null ,
     // ],
 
     // List of permissions a user MUST have in order to get access to the

--- a/schema/2022022201_2022081701.migration
+++ b/schema/2022022201_2022081701.migration
@@ -1,0 +1,18 @@
+/* users */
+ALTER TABLE users RENAME TO _users;
+
+CREATE TABLE IF NOT EXISTS users(
+    user_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    last_seen VARCHAR(255) NOT NULL,
+    permission_list TEXT NOT NULL,
+    auth_data TEXT DEFAULT NULL,
+    is_disabled BOOLEAN NOT NULL,
+    max_active_configurations VARCHAR(255) NULL,
+    max_active_api_configurations VARCHAR(255) NULL, 
+    connection_expires_at VARCHAR(255) NULL
+);
+
+INSERT INTO users (user_id, last_seen, permission_list, auth_data, is_disabled, max_active_api_configuration, session_expiry, expires_at) 
+SELECT (user_id, last_seen, permission_list, auth_data, is_disabled, max_active_api_configuration, session_expiry, expires_at)  FROM _users;
+
+DROP TABLE _users;

--- a/schema/2022081701.schema
+++ b/schema/2022081701.schema
@@ -1,0 +1,75 @@
+CREATE TABLE IF NOT EXISTS users(
+    user_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    last_seen VARCHAR(255) NOT NULL,
+    permission_list TEXT NOT NULL,
+    auth_data TEXT DEFAULT NULL,
+    is_disabled BOOLEAN NOT NULL,
+    max_active_configurations VARCHAR(255) NULL,
+    max_active_api_configurations VARCHAR(255) NULL,    
+    connection_expires_at VARCHAR(255)  NULL 
+);
+CREATE TABLE IF NOT EXISTS local_users (
+    user_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at VARCHAR(255) NOT NULL,
+    UNIQUE(user_id)
+);
+CREATE TABLE IF NOT EXISTS oauth_authorizations (
+    auth_key VARCHAR(255) NOT NULL PRIMARY KEY,
+    client_id VARCHAR(255) NOT NULL,
+    scope VARCHAR(255) NOT NULL,
+    authorized_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    UNIQUE(auth_key)
+);
+CREATE TABLE IF NOT EXISTS oauth_refresh_token_log (
+    auth_key VARCHAR(255) NOT NULL REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    refresh_token_id VARCHAR(255) NOT NULL,
+    UNIQUE(auth_key, refresh_token_id)
+);
+CREATE TABLE IF NOT EXISTS certificates(
+    node_number BIGINT NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    common_name VARCHAR(255) UNIQUE NOT NULL,
+    created_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    auth_key VARCHAR(255) REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS wg_peers (
+    node_number BIGINT NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    public_key VARCHAR(255) NOT NULL UNIQUE,
+    ip_four VARCHAR(255) NOT NULL UNIQUE,
+    ip_six VARCHAR(255) NOT NULL UNIQUE,
+    created_at VARCHAR(255) NOT NULL,
+    expires_at VARCHAR(255) NOT NULL,
+    auth_key VARCHAR(255) REFERENCES oauth_authorizations(auth_key) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS connection_log(
+    user_id VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    vpn_proto VARCHAR(255) NOT NULL,
+    connection_id VARCHAR(255) NOT NULL,
+    ip_four VARCHAR(255) NOT NULL,
+    ip_six VARCHAR(255) NOT NULL,
+    connected_at VARCHAR(255) NOT NULL,
+    bytes_in BIGINT DEFAULT NULL,
+    bytes_out BIGINT DEFAULT NULL,
+    disconnected_at VARCHAR(255) DEFAULT NULL
+);
+CREATE TABLE IF NOT EXISTS live_stats(
+    date_time VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    connection_count BIGINT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS aggregate_stats(
+    date VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(255) NOT NULL,
+    max_connection_count BIGINT NOT NULL,
+    unique_user_count BIGINT NOT NULL
+);

--- a/src/Cfg/Config.php
+++ b/src/Cfg/Config.php
@@ -210,6 +210,11 @@ class Config
         return new LdapAuthConfig($this->s('LdapAuthModule')->toArray());
     }
 
+    public function userConfig(): UserConfig
+    {
+        return new UserConfig($this->s('User')->toArray());
+    }
+
     /**
      * @psalm-suppress UnresolvableInclude
      */

--- a/src/Cfg/OidcAuthConfig.php
+++ b/src/Cfg/OidcAuthConfig.php
@@ -34,4 +34,19 @@ class OidcAuthConfig
     {
         return $this->requireStringArray('permissionAttributeList', []);
     }
+
+    public function maxActiveConfigurationsArribute(): string
+    {
+        return $this->optionalString('maxActiveConfigurations');
+    }
+
+    public function maxActiveApiConfigurationsAttribute(): string
+    {
+        return $this->optionalString('maxActiveApiConfigurations');
+    }
+
+    public function connectionExpiresAtAttribute(): string
+    {
+        return $this->optionalString('connectionExpiresAt');
+    }
 }

--- a/src/Cfg/ProfileConfig.php
+++ b/src/Cfg/ProfileConfig.php
@@ -245,4 +245,14 @@ class ProfileConfig
     {
         return \count($this->requireStringOrStringArray('nodeUrl', ['http://127.0.0.1:41194']));
     }
+
+    public function maxActiveConfigurations(): int
+    {
+        return $this->requireInt('maxActiveConfigurations', -1);
+    }
+
+    public function maxActiveApiConfigurations(): int
+    {
+        return $this->requireInt('maxActiveApiConfigurations', -1);
+    }
 }

--- a/src/Cfg/UserConfig.php
+++ b/src/Cfg/UserConfig.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * eduVPN - End-user friendly VPN.
+ *
+ * Copyright: 2016-2022, The Commons Conservancy eduVPN Programme
+ * SPDX-License-Identifier: AGPL-3.0+
+ */
+
+namespace Vpn\Portal\Cfg;
+
+
+class UserConfig
+{
+    use ConfigTrait;
+
+    private array $configData;
+
+    public function __construct(array $configData)
+    {
+        $this->configData = $configData;
+    }
+
+
+    public function connectionExpiresAt(): bool
+    {
+        return $this->requireBool('connectionExpiresAt', false);
+    }
+
+    public function maxActiveConfigurations(): bool
+    {
+        return $this->requireBool('maxActiveConfigurations', false);
+    }
+
+    public function maxActiveApiConfigurations(): bool
+    {
+        return $this->requireBool('maxActiveApiConfigurations', false);
+    }
+
+}

--- a/src/Http/Auth/LdapCredentialValidator.php
+++ b/src/Http/Auth/LdapCredentialValidator.php
@@ -69,10 +69,11 @@ class LdapCredentialValidator implements CredentialValidatorInterface
                 //     id, e.g. mail, ipaUniqueID, ...
                 $userId = $this->getUserId($baseDn, $userFilter, $userIdAttribute);
             }
-
+            $settings = [];
+            $settings['permissionList'] = $this->getPermissionList($baseDn, $userFilter, $this->ldapAuthConfig->permissionAttributeList());
             return new UserInfo(
                 $userId,
-                $this->getPermissionList($baseDn, $userFilter, $this->ldapAuthConfig->permissionAttributeList())
+                $settings
             );
         } catch (LdapClientException $e) {
             // convert LDAP errors into `CredentialValidatorException`

--- a/src/Http/Auth/MellonAuthModule.php
+++ b/src/Http/Auth/MellonAuthModule.php
@@ -50,10 +50,11 @@ class MellonAuthModule extends AbstractAuthModule
                 $permissionList = array_merge($permissionList, explode(';', $permissionAttributeValue));
             }
         }
-
+        $settings = [];
+        $settings['permissionList'] = $permissionList;
         return new UserInfo(
             $userId,
-            $permissionList
+            $settings
         );
     }
 

--- a/src/Http/Auth/OidcAuthModule.php
+++ b/src/Http/Auth/OidcAuthModule.php
@@ -36,9 +36,15 @@ class OidcAuthModule extends AbstractAuthModule
             }
         }
 
+        $settings = [];
+        $settings['permissionList'] = $permissionList;
+        $settings['maxActiveConfigurations'] = $request->optionalHeader($this->config->maxActiveConfigurationsArribute());
+        $settings['maxActiveApiConfigurations'] = $request->optionalHeader($this->config->maxActiveApiConfigurationsAttribute());
+        $settings['connectionExpiresAt'] = $request->optionalHeader($this->config->connectionExpiresAtAttribute());
+
         return new UserInfo(
             $request->requireHeader($this->config->userIdAttribute()),
-            $permissionList
+            $settings
         );
     }
 

--- a/src/Http/Auth/PhpSamlSpAuthModule.php
+++ b/src/Http/Auth/PhpSamlSpAuthModule.php
@@ -46,9 +46,11 @@ class PhpSamlSpAuthModule extends AbstractAuthModule
             throw new HttpException(sprintf('missing SAML user_id attribute "%s"', $userIdAttribute), 500);
         }
 
+        $settings = [];
+        $settings['permissionList'] = $this->getPermissionList($samlAttributes);
         return new UserInfo(
             $samlAttributes[$userIdAttribute][0],
-            $this->getPermissionList($samlAttributes)
+            $settings
         );
     }
 

--- a/src/Http/Auth/RadiusCredentialValidator.php
+++ b/src/Http/Auth/RadiusCredentialValidator.php
@@ -102,7 +102,8 @@ class RadiusCredentialValidator implements CredentialValidatorInterface
                 $permissionList[] = $radiusAttribute['data'];
             }
         }
-
-        return new UserInfo($authUser, $permissionList);
+        $settings = [];
+        $settings['permissionList'] = $permissionList;
+        return new UserInfo($authUser, $settings);
     }
 }

--- a/src/Http/Auth/ShibAuthModule.php
+++ b/src/Http/Auth/ShibAuthModule.php
@@ -35,9 +35,11 @@ class ShibAuthModule extends AbstractAuthModule
             }
         }
 
+        $settings = [];
+        $settings['permissionList'] = $permissionList;
         return new UserInfo(
             $request->requireHeader($this->config->userIdAttribute()),
-            $permissionList
+            $settings
         );
     }
 

--- a/src/Http/Auth/UserPassAuthModule.php
+++ b/src/Http/Auth/UserPassAuthModule.php
@@ -86,10 +86,11 @@ class UserPassAuthModule extends AbstractAuthModule
         if (null !== $sessionValue = $this->session->get('_user_pass_auth_permission_list')) {
             $permissionList = Json::decode($sessionValue);
         }
-
+        $settings = [];
+        $settings['permissionList'] = $permissionList;
         return new UserInfo(
             $authUser,
-            $permissionList
+            $settings
         );
     }
 

--- a/src/Http/UserInfo.php
+++ b/src/Http/UserInfo.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Vpn\Portal\Http;
 
+
 class UserInfo
 {
     private string $userId;
@@ -18,18 +19,27 @@ class UserInfo
     private bool $isAdmin = false;
 
     /** @var array<string> */
-    private array $permissionList;
+    //private array $permissionList;
 
     private ?string $authData;
+
+    private array $settings;
+
 
     /**
      * @param array<string> $permissionList
      */
-    public function __construct(string $userId, array $permissionList, ?string $authData = null)
+    public function __construct(string $userId, array $settings, ?string $authData = null)
     {
         $this->userId = $userId;
-        $this->permissionList = $permissionList;
+        //$this->permissionList = $settings['permissionList'];
         $this->authData = $authData;
+        $this->settings = $settings;
+        $this->settings['maxActiveConfigurations'] = @$settings['maxActiveConfigurations'] ?: '-1' ;
+        $this->settings['maxActiveApiConfigurations'] = @$settings['maxActiveApiConfigurations'] ?: '-1';
+        $this->settings['connectionExpiresAt'] = @$settings['connectionExpiresAt'] ?: null;
+   
+        
     }
 
     public function userId(): string
@@ -52,11 +62,16 @@ class UserInfo
      */
     public function permissionList(): array
     {
-        return $this->permissionList;
+        return $this->$settings['permissionList'];
     }
 
     public function authData(): ?string
     {
         return $this->authData;
+    }
+
+    public function settings(string $key): string
+    {
+        return $this->$settings[$key];
     }
 }


### PR DESCRIPTION
This change include scenarios and features where
1. The need to disable/limit portal configuration for specific profiles, while enabled globally. same applies to api configuration.
2. The need to disable/limit portal/api configuration for specific users even if profile/global configuration allows otherwise.
3. Connection expiry for users where users can connect to the service till that date (specific date not interval). the expire_at has no effect on authorizations, but only connect.
4. When all user limits config are enabled, only users with assigned attribute value from AuthModule will have the limits applied. users with default values (-1 / null) will subject to profile/global settings.
5. Supersedence for configuration in order by global, profile then user.
6. Profile settings are configured in config.php
7. User settings are enabled in config.php, and set through Auth Module attributes (OIDC is configured in this pull)

  
***config.php***
```
return [

     'User' => [
          'maxActiveConfigurations' => false,
          'maxActiveApiConfigurations' => false,
          'connectionExpiresAt' => false,
     ],
     ..
     ..
    ProfileList' => [
          [   'profileId' => 'default',
               ....
              'maxActiveConfigurations' => -1,
              'maxActiveApiConfigurations' => -1,
          ],
     ],
  ]           
```


***schema***
3 fields are added to `users` table 
- `max_active_api_configurations`
- `max_active_configurations`
- `connection_expires_at`

***UserInfo*** Class
- reconfigured  private array $permissionList 
     - renamed to $settings.
	 - assign  parameter $permissionList to a key in $settings
     - added keys for user level controls
        - `maxActiveConfigurations` (default = -1) 
  		- `maxActiveApiConfigurations` (default = -1) 
        - `connectionExpiresAt` (default = null) 

all classes using UserInfo $permissionList was updated to reflect changes
-	AuthModules `LdapCredentialValidator`	`MellonAuthModule` `OidcAuthModule` `PhpSamlSpAuthModule` `ShibAuthModule` `UserPassAuthModule`
-	Storage functions updated 


implement control in 


1. `VpnApiThreeModule` (API configuration)
```
        $service->post(
            '/v3/connect'
```

2. `VpnPortalModule` (manual configuration)
```
        $service->post(
            '/addConfig',
```